### PR TITLE
Fixed HTML::Template objects creations (utf8 support).

### DIFF
--- a/lib/Templer/Site.pm
+++ b/lib/Templer/Site.pm
@@ -455,6 +455,7 @@ sub build
                          search_path_on_include => 1,
                          global_vars            => 1,
                          loop_context_vars      => 1,
+                         utf8                   => 1,
           );
 
         #
@@ -532,6 +533,7 @@ sub build
                                         search_path_on_include => 1,
                                         global_vars            => 1,
                                         loop_context_vars      => 1,
+                                        utf8                   => 1,
                                       );
 
 


### PR DESCRIPTION
HTML::Template object creations in Site.pm did not specifiy support for UTF-8
which is a trouble at least when the layouyt contains some UTF-8 encoded
characters.

I added the `utf8 => 1` parameter for both object creation (against layout and
body).

This is a duplication of commit 7467e4b901c7a881453749280632e31da94cd9d3 (I
scrambled my branches).
