### PR TITLE
Allow format variable to be defined in main configuration file.

### DIFF
--- a/lib/Templer/Site/Page.pm
+++ b/lib/Templer/Site/Page.pm
@@ -179,7 +179,7 @@ sub content
     #  The content we read from the page.
     #
     my $content = $self->{ 'content' };
-    my $format = $self->{ 'format' } || undef;
+    my $format = $self->{ 'format' } || $data->{ 'format' } || undef;
 
     #
     #  Do we have a formatter plugin for this type?


### PR DESCRIPTION
It may be useful to be able to defined a default formatter, or formatters
pipeline, for a whole site (every page written in Markdown for instance).

That was not possible since the format variable used in Page.pm was just the
one read from the page file. Every page should then specify the formatter (or
formatters pipeline) which could be annoying.

I changed the way format is retrieved in Page.pm.

That said this behavior may have been set up on purpose : enforce every page
not written in HTML::Template format to embed their format in their
meta-data. In that way pages may be moved from one site to another
independantly of the site config file.
