### PR TITLE
Propagate the --debug flag only if it has been found.

### DIFF
--- a/templer.in
+++ b/templer.in
@@ -67,8 +67,15 @@ if ( !defined( $CONFIG{ 'config' } ) )
 # templer.cfg.
 #
 my $cnf = $CONFIG{ 'config' } || "./templer.cfg";
-my $cfg = Templer::Global->new( file => $cnf, debug => $CONFIG{ 'debug' } );
-
+my $cfg;
+if ( defined( $CONFIG{ 'debug' } ) )
+{
+  $cfg = Templer::Global->new( file => $cnf, debug => $CONFIG{ 'debug' } );
+}
+else
+{
+  $cfg = Templer::Global->new( file => $cnf);
+}
 
 #
 # These are the default settings.


### PR DESCRIPTION
I think commit 3b15bfe298479fc847ff4bc2119507ae338f2a9f introduced a bug.

Creating the Templer::Global object with debug key fixed to the `undef`
value (which is the case if no --debug was set on the command line) cause
troubles. In this case, since debug has a value it cannot be merged with the
default settings and any use of debug field throw an error.

In order to keep the default settings at one place only in the code I added a
test to propagate the --debug to the creator method only if it has been asked.
