### PR TITLE
Updated FileGlob plugin to populate file name parts.

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -22,8 +22,10 @@ The following variable plugins are distributed as part of the project:
    * Set variable values to the contents of files.
 * `Templer::Plugin::FileGlob`
    * Set variable values to lists of files, based on a globbing pattern.
+   * dirname, basename and file extension are made available.
    * If the glob matches images then heights and widths will be available to your HTML.
    * If the glob doesn't match images then the contents of the files will also be made available.
+   * If the glob matches templer input files then templer input variables will be available to your HTML.
 * `Templer::Plugin::ShellCommand`
    * Set variable values to the output of shell commands.
 * `Templer::Plugin::RootPath`

--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ If your glob matches files which are not images it will populate the member `con
 
 This assumes you have files such as <tt>news-20130912.txt</tt>, etc, and will show the contents of each file in (glob)order.</p>
 
+If matching files are templer input files then all templer variables are populated instead of the text-content of the matching files.
+
+In all cases it will populate `dirname`, `basename` and `extension`, being parts of each matching files name.
+
 
 File Inclusion
 --------------

--- a/lib/Templer/Plugin/FileGlob.pm
+++ b/lib/Templer/Plugin/FileGlob.pm
@@ -44,7 +44,26 @@ The height of the image, if the file is an image and L<Image::Size> is available
 
 The width of the image, if the file is an image and L<Image::Size> is available.
 
+=item content
+
+The content of the file if the file is not an image and not a templer input file.
+
+=item dirname
+
+The directory part of the file name.
+
+=item basename
+
+The basename of the file (without extension).
+
+=item extension
+
+The extension (everything after the last period) of the file name.
+
 =back
+
+If matching files are templer input files then all templer variables are also
+populated.
 
 =cut
 
@@ -88,6 +107,7 @@ use warnings;
 package Templer::Plugin::FileGlob;
 
 use Cwd;
+use File::Basename;
 
 
 =head2
@@ -231,6 +251,14 @@ sub expand_variables
                         close($handle);
                     }
                 }
+
+                #
+                # Populate filename parts
+                #
+                my($basename, $dirname, $extension) = fileparse($img);
+                ($meta { 'dirname' } = $dirname) =~ s{/$}{};
+                ($meta { 'basename' } = $basename) =~ s{(.*)\.([^.]*)$}{$1};
+                $meta { 'extension' } = $2;
 
                 push( @$ref, \%meta );
             }


### PR DESCRIPTION
For each matched files we populate three variables corresponding to the
three _natural_ parts of a filename: dirname, basename and extension (being
everything after the last period). One use case is when we have a gallery with
different version of the same file (`.svg`, `.pdf`, `.eps`, `.png`, etc.).

I also updated some documentation about hidden, nice (untested ;-) FileGlob
features (when matched files are templer input files).
