### PR TITLE
Added *synchronized* mode of building site.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ transformation:
     robots.txt          [Ignored and left un-modified.]
     ..
 
+There is _also_ a *synchronized* mode. When working synchronized any file in
+the output directory which do not have a source file in input directory (page
+or asset) is removed each time the site is rebuild.
+
 
 Pages
 -----
@@ -436,6 +440,7 @@ In brief the control flow goes like this:
     * Each page is output.
     * The plugins are unloaded.
 * The assets are copied via `Templer::Site::copyAssets()`.
+* The output directory is cleaned via `Templer::Site::sync()`.
 * The build-time/build-count is reported and the process is complete.
 
 Each of the modules has a simple test-case associated with it.  To test functionality, especially after making changes, please run the test-suite:

--- a/t/test-templer-plugin-filters.t
+++ b/t/test-templer-plugin-filters.t
@@ -3,8 +3,7 @@
 #  Test we can instantiate the known filter-plugins, and that
 # they work when Templer::Site use HTTML::Template.
 #
-# Steve
-# --
+# Bruno
 #
 
 use strict;

--- a/t/test-templer-synchronization.t
+++ b/t/test-templer-synchronization.t
@@ -1,0 +1,141 @@
+#!/usr/bin/perl -Ilib/ -I../lib/ -w
+#
+# Test that the Templer::Site::sync method will do the right
+# thing.
+#
+# Bruno
+#
+
+use strict;
+use warnings;
+
+use Test::More qw! no_plan !;
+use File::Temp qw! tempdir !;
+use File::Path qw! mkpath !;
+
+#
+# Load needed objects
+#
+BEGIN {use_ok('Templer::Site');}
+require_ok('Templer::Site');
+
+BEGIN {use_ok('Templer::Plugin::Factory');}
+require_ok('Templer::Plugin::Factory');
+
+BEGIN {use_ok('Templer::Site::Page');}
+require_ok('Templer::Site::Page');
+
+BEGIN {use_ok('Templer::Site::Asset');}
+require_ok('Templer::Site::Asset');
+
+#
+# Make a temporary directory
+#
+my $tmp = tempdir( CLEANUP => 0 );
+ok( -d $tmp, "We created a temporary directory" );
+note("Temporary directory is: $tmp");
+
+#
+# Make the input-subdirectory
+#
+File::Path::mkpath( $tmp . "/input", { verbose => 0, mode => oct(755) } );
+ok( -d $tmp . "/input", "We created an input/ directory" );
+
+#
+# Create a layout file.
+#
+File::Path::mkpath( $tmp . "/layouts", { verbose => 0, mode => oct(755) } );
+ok( -d $tmp . "/layouts", "We created a layouts directory" );
+
+open( my $handle, ">", $tmp . "/layouts/default.layout" );
+print $handle <<EOF;
+<title><tmpl_var name="title"/></title>
+EOF
+close($handle);
+ok( -f $tmp . "/layouts/default.layout", "We created a layout file" );
+
+#
+# Create a page
+#
+open( $handle, ">", $tmp . "/input/index.skx" );
+print $handle <<EOF;
+Title: This is my page title.
+----
+This is my page content.
+EOF
+close($handle);
+ok( -f $tmp . "/input/index.skx", "We created a source page" );
+
+#
+# Create some assets
+#
+createFile( $tmp . "/input/logo.png" );
+createFile( $tmp . "/input/.htaccess" );
+
+#
+#  Now create the Templer::Site object.
+#
+my %data = ( "in-place"     => 0,
+             "include-path" => "$tmp/includes",
+             "input"        => "$tmp/input/",
+             "layout"       => "default.layout",
+             "layout-path"  => "$tmp/layouts",
+             "output"       => "$tmp/output/",
+             "plugin-path"  => "$tmp/plugins",
+             "suffix"       => ".skx",
+             "verbose"      => 0,
+             "debug"        => 0,
+             "force"        => 0,
+             "sync"         => 1,
+           );
+my $site = Templer::Site->new(%data);
+isa_ok( $site, "Templer::Site" );
+
+#
+# Setup the output directory, etc.
+#
+$site->init();
+ok( -d "$tmp/output", "The output directory was created" );
+
+#
+# Create garbage directory
+#
+File::Path::mkpath( $tmp . "/output/garbage",
+                    { verbose => 0, mode => oct(755) } );
+ok( -d $tmp, "We created an output/garbage empty directory" );
+
+#
+# Create garbage file
+#
+createFile( $tmp . "/output/garbage.png" );
+ok( -e $tmp . "/output/garbage.png", "We created an output/garbage file" );
+
+#
+# Generate everything
+#
+$site->build();
+$site->copyAssets();
+$site->sync();
+
+ok( -e $tmp . "/output/index.html", "Page generated correctly" );
+ok( -e $tmp . "/output/logo.png",   "Asset copied successfully" );
+ok( -e $tmp . "/output/.htaccess",  "Asset copied successfully" );
+ok( !-e $tmp . "/garbage.png",      "Garbage file removed correctly" );
+ok( !-e $tmp . "/garbage",          "Garbage directory removed correctly" );
+
+
+sub createFile
+{
+    my ($file) = (@_);
+
+    ok( !-e $file, "The file didn't exist prior to creation" );
+
+    note("File to be created is : $file");
+
+    open( my $handle, ">", $file ) or
+      die "Failed to write: $file - $!";
+    print $handle "\n";
+    close($handle);
+
+    ok( -e $file, "The file was created" );
+}

--- a/templer.cfg.sample
+++ b/templer.cfg.sample
@@ -93,6 +93,15 @@ format = html
 ##
 
 
+##
+#
+# If we're working synchronized then files in output must have a source file
+# in input or else they are removed
+#
+# sync = 1
+#
+##
+
 
 ##
 #

--- a/templer.in
+++ b/templer.in
@@ -85,6 +85,7 @@ my %DEFAULTS = ( "in-place"     => 0,
                  "verbose"      => ( $CONFIG{ 'verbose' } || 0 ),
                  "debug"        => ( $CONFIG{ 'debug' } || 0 ),
                  "force"        => ( $CONFIG{ 'force' } || 0 ),
+                 "sync"         => ( $CONFIG{ 'sync' } || 0 ),
                );
 
 
@@ -158,6 +159,10 @@ my $rebuilt = $site->build();
 #
 $site->copyAssets();
 
+#
+#  Synchronize destination with input
+#
+$site->sync();
 
 #
 #  Run any post-build commands the user might have defined.


### PR DESCRIPTION
When we build a site and that a page (or an asset) have been removed from the
input, templer does not remove the corresponding file from the output. Now
when the `sync` variable is set to 1 these kind of file are removed.
