### PR TITLE
allow to use $site->pages and $site->assets as documented in the synopsis

### DIFF
--- a/lib/Templer/Site.pm
+++ b/lib/Templer/Site.pm
@@ -93,6 +93,8 @@ use Data::Dumper;
 use File::Find;
 use File::Path qw! mkpath !;
 use HTML::Template;
+use Templer::Site::Page;
+use Templer::Site::Asset;
 
 
 
@@ -208,7 +210,7 @@ sub pages
 {
     my ( $self, %args ) = (@_);
 
-    my $dir    = $args{ 'directory' } || $self->{ 'directory' };
+    my $dir    = $args{ 'directory' } || $self->{ 'directory' } || $self->{ 'input' };
     my $suffix = $args{ 'suffix' }    || $self->{ 'suffix' };
 
     return (
@@ -236,7 +238,7 @@ sub assets
 {
     my ( $self, %args ) = (@_);
 
-    my $dir    = $args{ 'directory' } || $self->{ 'directory' };
+    my $dir    = $args{ 'directory' } || $self->{ 'directory' } || $self->{ 'input' };
     my $suffix = $args{ 'suffix' }    || $self->{ 'suffix' };
 
     return (

--- a/t/test-templer-site-synopsis.t
+++ b/t/test-templer-site-synopsis.t
@@ -1,0 +1,58 @@
+#!/usr/bin/perl -Ilib/ -I../lib/ -w
+#
+# Test that the Templer::Site synopsis code works
+#
+
+
+use strict;
+use warnings;
+
+use Test::More qw! no_plan !;
+use File::Temp qw! tempdir !;
+use File::Path qw! mkpath !;
+
+
+BEGIN {use_ok('Templer::Site');}
+require_ok('Templer::Site');
+
+
+#
+#  Make a temporary directory
+#
+my $tmp = tempdir( CLEANUP => 1 );
+ok( -d $tmp, "We created a temporary directory" );
+
+#
+#  Make the input-subdirectory
+#
+File::Path::mkpath( $tmp . "/input", { verbose => 0, mode => oct(755) } );
+ok( -d $tmp, "We created an input/ directory" );
+open( my $pagefile, '>', $tmp . "/input/test.skx" );
+print $pagefile "test page";
+close( $pagefile);
+
+open( my $assetfile, '>', $tmp . "/input/test.css" );
+print $assetfile "test asset";
+close( $assetfile);
+
+
+
+#
+#  Now create the Templer::Site object.
+#
+my $site = Templer::Site->new( suffix     => ".skx",
+                               input      => "$tmp/input",
+                               output     => "$tmp/output"
+                             );
+
+#
+#  Get pages
+#
+my @pages  = $site->pages();
+ok( scalar(@pages) == 1, "one page");
+
+#
+#  Get assets
+#
+my @assets  = $site->assets();
+ok( scalar(@assets) == 1, "one asset");


### PR DESCRIPTION
For a plugin I wanted to use $site->pages() as documented in the synopsis. It did not work as it wanted the input directory as argument. I changed now the pages and assets methods to use the input directory automatically if no directory argument is available.